### PR TITLE
chore: update stack Docker images

### DIFF
--- a/internal/service/assets/docker-compose.yaml.tmpl
+++ b/internal/service/assets/docker-compose.yaml.tmpl
@@ -2,7 +2,7 @@
 services:
   grafana:
     container_name: grafana
-    image: grafana/grafana:12.4.2
+    image: grafana/grafana:13.0.1
     environment:
       - GF_SERVER_ROOT_URL={{ .RootUrl }}/grafana
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
@@ -94,7 +94,7 @@ services:
 
   alloy:
     container_name: alloy
-    image: grafana/alloy:v1.15.0
+    image: grafana/alloy:v1.15.1
     volumes:
       - /var/lib/finch/alloy/etc:/etc/alloy
       - /var/lib/finch/alloy/data:/var/lib/alloy/data
@@ -132,7 +132,7 @@ services:
 
   pyroscope:
     container_name: pyroscope
-    image: grafana/pyroscope:1.20.3
+    image: grafana/pyroscope:1.21.0
     volumes:
       - /var/lib/finch/pyroscope/data:/var/lib/pyroscope
       - /var/lib/finch/pyroscope/etc:/etc/pyroscope


### PR DESCRIPTION
Automated update of Docker image versions in the stack.

This PR updates the following images to their latest versions:
- Grafana
- Loki
- Traefik
- Alloy
- Mimir
- Pyroscope

Please review the changes before merging.