### PR TITLE
chore: update stack Docker images

### DIFF
--- a/internal/service/assets/docker-compose.yaml.tmpl
+++ b/internal/service/assets/docker-compose.yaml.tmpl
@@ -81,7 +81,7 @@ services:
 
   traefik:
     container_name: traefik
-    image: traefik:v3.7.6
+    image: traefik:v3.7.7
     command:
       - "--configfile=/etc/traefik/traefik.yaml"
     ports:
@@ -132,7 +132,7 @@ services:
 
   pyroscope:
     container_name: pyroscope
-    image: grafana/pyroscope:2.1.0
+    image: grafana/pyroscope:2.1.1
     volumes:
       - /var/lib/finch/pyroscope/data:/var/lib/pyroscope
       - /var/lib/finch/pyroscope/etc:/etc/pyroscope


### PR DESCRIPTION
Automated update of Docker image versions in the stack.

This PR updates the following images to their latest versions:
- Grafana
- Loki
- Traefik
- Alloy
- Mimir
- Pyroscope

Please review the changes before merging.