### PR TITLE
chore: update stack Docker images

### DIFF
--- a/internal/service/assets/docker-compose.yaml.tmpl
+++ b/internal/service/assets/docker-compose.yaml.tmpl
@@ -81,7 +81,7 @@ services:
 
   traefik:
     container_name: traefik
-    image: traefik:v3.7.7
+    image: traefik:v3.7.8
     command:
       - "--configfile=/etc/traefik/traefik.yaml"
     ports:
@@ -118,7 +118,7 @@ services:
 
   mimir:
     container_name: mimir
-    image: grafana/mimir:3.1.2
+    image: grafana/mimir:3.1.3
     volumes:
       - /var/lib/finch/mimir/data:/var/lib/mimir
       - /var/lib/finch/mimir/etc:/etc/mimir


### PR DESCRIPTION
Automated update of Docker image versions in the stack.

This PR updates the following images to their latest versions:
- Grafana
- Loki
- Traefik
- Alloy
- Mimir
- Pyroscope

Please review the changes before merging.