### PR TITLE
chore: update stack Docker images

### DIFF
--- a/internal/service/assets/docker-compose.yaml.tmpl
+++ b/internal/service/assets/docker-compose.yaml.tmpl
@@ -2,7 +2,7 @@
 services:
   grafana:
     container_name: grafana
-    image: grafana/grafana:13.1.0
+    image: grafana/grafana:13.1.1
     environment:
       - GF_SERVER_ROOT_URL={{ .RootUrl }}/grafana
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
@@ -67,7 +67,7 @@ services:
 
   loki:
     container_name: loki
-    image: grafana/loki:3.7.3
+    image: grafana/loki:3.7.4
     command:
       - "-config.file=/etc/loki/loki.yaml"
       - "-target=all"
@@ -81,7 +81,7 @@ services:
 
   traefik:
     container_name: traefik
-    image: traefik:v3.7.8
+    image: traefik:v3.7.9
     command:
       - "--configfile=/etc/traefik/traefik.yaml"
     ports:
@@ -94,7 +94,7 @@ services:
 
   alloy:
     container_name: alloy
-    image: grafana/alloy:v1.17.1
+    image: grafana/alloy:v1.18.0
     volumes:
       - /var/lib/finch/alloy/etc:/etc/alloy
       - /var/lib/finch/alloy/data:/var/lib/alloy/data
@@ -118,7 +118,7 @@ services:
 
   mimir:
     container_name: mimir
-    image: grafana/mimir:3.1.3
+    image: grafana/mimir:3.1.4
     volumes:
       - /var/lib/finch/mimir/data:/var/lib/mimir
       - /var/lib/finch/mimir/etc:/etc/mimir
@@ -132,7 +132,7 @@ services:
 
   pyroscope:
     container_name: pyroscope
-    image: grafana/pyroscope:2.1.1
+    image: grafana/pyroscope:2.2.0
     volumes:
       - /var/lib/finch/pyroscope/data:/var/lib/pyroscope
       - /var/lib/finch/pyroscope/etc:/etc/pyroscope


### PR DESCRIPTION
Automated update of Docker image versions in the stack.

This PR updates the following images to their latest versions:
- Grafana
- Loki
- Traefik
- Alloy
- Mimir
- Pyroscope

Please review the changes before merging.